### PR TITLE
Support wasmtime-21.0.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689806338,
-        "narHash": "sha256-WB5hYFIX6Q4nSJffn7sSh5WoScTjAvXwIdLqLhKZXYs=",
+        "lastModified": 1716715802,
+        "narHash": "sha256-usk0vE7VlxPX8jOavrtpOqphdfqEQpf9lgedlY/r66c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7666089f26ed074d6b3ddf9c1ad9322ac7fecb37",
+        "rev": "e2dd4e18cc1c7314e24154331bae07df76eb582f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-23.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -59,16 +59,16 @@
     "wasmtime": {
       "flake": false,
       "locked": {
-        "lastModified": 1687385532,
-        "narHash": "sha256-tDo3f2Drjgs0PSu2dWGomO+iyS96Df2891TQxAew4YE=",
+        "lastModified": 1716235049,
+        "narHash": "sha256-ntnylMxrPKhmo1JG55/A3j/HUGsNNwlsQ9yN/hveaaA=",
         "owner": "bytecodealliance",
         "repo": "wasmtime",
-        "rev": "a45abadbc39a57dd3e404231e2751a80cdafa4b0",
+        "rev": "aaa39cb71ac09a518ce4563b61fe102cfa66333e",
         "type": "github"
       },
       "original": {
         "owner": "bytecodealliance",
-        "ref": "v10.0.1",
+        "ref": "v21.0.0",
         "repo": "wasmtime",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,10 @@
   description = "wasmtime-hs";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-23.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     wasmtime = {
-      url = "github:bytecodealliance/wasmtime/v10.0.1";
+      url = "github:bytecodealliance/wasmtime/v21.0.0";
       flake = false;
     };
   };
@@ -54,6 +54,7 @@
         packages.hello-c = check_c_example "hello";
         packages.gcd-c = check_c_example "gcd";
         packages.memory-c = check_c_example "memory";
+        packages.fuel-c = check_c_example "fuel";
 
         # The default development shell brings in all dependencies of
         # wasmtime-hs (like all Haskell dependencies, libwasmtime, GHC).

--- a/lib/Bindings/Wasmtime/Extern.hsc
+++ b/lib/Bindings/Wasmtime/Extern.hsc
@@ -13,29 +13,29 @@ import Bindings.Wasmtime.Store
 import Data.Word (Word64)
 
 #starttype struct wasmtime_func
-#field store_id , Word64
-#field index    , CSize
+#field store_id  , Word64
+#field __private , CSize
 #stoptype
 
 #synonym_t wasmtime_func_t , <wasmtime_func>
 
 #starttype struct wasmtime_table
-#field store_id , Word64
-#field index    , CSize
+#field store_id  , Word64
+#field __private , CSize
 #stoptype
 
 #synonym_t wasmtime_table_t , <wasmtime_table>
 
 #starttype struct wasmtime_memory
-#field store_id , Word64
-#field index    , CSize
+#field store_id  , Word64
+#field __private , CSize
 #stoptype
 
 #synonym_t wasmtime_memory_t , <wasmtime_memory>
 
 #starttype struct wasmtime_global
-#field store_id , Word64
-#field index    , CSize
+#field store_id  , Word64
+#field __private , CSize
 #stoptype
 
 #synonym_t wasmtime_global_t , <wasmtime_global>

--- a/lib/Bindings/Wasmtime/Store.hsc
+++ b/lib/Bindings/Wasmtime/Store.hsc
@@ -49,17 +49,11 @@ import Data.Word (Word64)
 #ccall_unsafe wasmtime_context_gc , \
   Ptr <wasmtime_context_t> -> IO ()
 
-#ccall_unsafe wasmtime_context_add_fuel , \
+#ccall_unsafe wasmtime_context_set_fuel , \
   Ptr <wasmtime_context_t> -> Word64 -> IO (Ptr <wasmtime_error_t>)
 
-#ccall_unsafe wasmtime_context_fuel_consumed ,\
-  Ptr <wasmtime_context_t> -> Ptr Word64 -> IO Bool
-
-#ccall_unsafe wasmtime_context_fuel_remaining , \
-  Ptr <wasmtime_context_t> -> Ptr Word64 -> IO Bool
-
-#ccall_unsafe wasmtime_context_consume_fuel , \
-  Ptr <wasmtime_context_t> -> Word64 -> Ptr Word64 -> IO (Ptr <wasmtime_error_t>)
+#ccall_unsafe wasmtime_context_get_fuel , \
+  Ptr <wasmtime_context_t> -> Ptr Word64 -> IO (Ptr <wasmtime_error_t>)
 
 #ccall_unsafe wasmtime_context_set_wasi, \
   Ptr <wasmtime_context_t> -> Ptr <wasi_config_t> -> IO (Ptr <wasmtime_error_t>)

--- a/lib/Bindings/Wasmtime/Val.hsc
+++ b/lib/Bindings/Wasmtime/Val.hsc
@@ -13,31 +13,21 @@ import Bindings.Wasmtime.Store
 import Data.Int
 import Data.WideWord.Word128 (Word128)
 
-#opaque_t wasmtime_externref
+#starttype struct wasmtime_anyref
+#field store_id   , Word64
+#field __private1 , Word32
+#field __private2 , Word32
+#stoptype
+
+#synonym_t wasmtime_anyref_t , <wasmtime_anyref>
+
+#starttype struct wasmtime_externref
+#field store_id   , Word64
+#field __private1 , Word32
+#field __private2 , Word32
+#stoptype
 
 #synonym_t wasmtime_externref_t , <wasmtime_externref>
-
-#ccall_unsafe wasmtime_externref_new , \
-  Ptr () -> \
-  FunPtr (Ptr () -> IO ()) -> \
-  IO (Ptr <wasmtime_externref_t>)
-
-#ccall_unsafe wasmtime_externref_data , \
-  Ptr <wasmtime_externref_t> -> IO (Ptr ())
-
-#ccall_unsafe wasmtime_externref_clone , \
-  Ptr <wasmtime_externref_t> -> IO (Ptr <wasmtime_externref_t>)
-
-#ccall_unsafe wasmtime_externref_delete , \
-  Ptr <wasmtime_externref_t> -> IO ()
-
-#ccall_unsafe wasmtime_externref_from_raw , \
-  Ptr <wasmtime_context_t> -> Ptr () -> IO (Ptr <wasmtime_externref_t>)
-
-#ccall_unsafe wasmtime_externref_to_raw , \
-  Ptr <wasmtime_context_t> -> \
-  Ptr <wasmtime_externref_t> -> \
-  IO (Ptr ())
 
 #synonym_t wasmtime_valkind_t , Word8
 
@@ -50,14 +40,16 @@ import Data.WideWord.Word128 (Word128)
 #num WASMTIME_V128
 #num WASMTIME_FUNCREF
 #num WASMTIME_EXTERNREF
+#num WASMTIME_ANYREF
 
 #starttype union wasmtime_valunion
 #field i32 , Int32
 #field i64 , Int64
 #field f32 , Float
 #field f64 , Double
-#field funcref , <wasmtime_func>
-#field externref , Ptr <wasmtime_externref_t>
+#field anyref , <wasmtime_anyref_t>
+#field externref , <wasmtime_externref_t>
+#field funcref , <wasmtime_func_t>
 #field v128 , <wasmtime_v128>
 #stoptype
 
@@ -69,8 +61,9 @@ import Data.WideWord.Word128 (Word128)
 #field f32       , Float
 #field f64       , Double
 #field v128      , <wasmtime_v128>
+#field anyref    , Word32
+#field externref , Word32
 #field funcref   , Ptr ()
-#field externref , Ptr ()
 #stoptype
 
 #synonym_t wasmtime_val_raw_t , <wasmtime_val_raw>
@@ -81,9 +74,3 @@ import Data.WideWord.Word128 (Word128)
 #stoptype
 
 #synonym_t wasmtime_val_t , <wasmtime_val>
-
-#ccall_unsafe wasmtime_val_delete , \
-  Ptr <wasmtime_val_t> -> IO ()
-
-#ccall_unsafe wasmtime_val_copy , \
-  Ptr <wasmtime_val_t> -> Ptr <wasmtime_val_t> -> IO ()

--- a/test/fuel.wat
+++ b/test/fuel.wat
@@ -2,7 +2,7 @@
   (func $fibonacci (param $n i32) (result i32)
     (if
       (i32.lt_s (local.get $n) (i32.const 2))
-      (return (local.get $n))
+      (then (return (local.get $n)))
     )
     (i32.add
       (call $fibonacci (i32.sub (local.get $n) (i32.const 1)))

--- a/wasmtime-hs.cabal
+++ b/wasmtime-hs.cabal
@@ -70,6 +70,7 @@ test-suite inc-st
     build-depends:    base >=4.15
     build-depends:    bytestring
     build-depends:    primitive
+    build-depends:    transformers
     build-depends:    wasmtime-hs
     build-depends:    tasty-hunit >= 0.10.0
 


### PR DESCRIPTION
This ensures wasmtime-hs builds against the latest wasmtime (v21). It doesn't ensure all new features in wasmtime have a binding in wasmtime-hs. That's saved for another set of PRs.