### PR TITLE
feat: Link WASI

### DIFF
--- a/lib/Bindings/Wasi.hsc
+++ b/lib/Bindings/Wasi.hsc
@@ -9,3 +9,9 @@ module Bindings.Wasi where
 #strict_import
 
 #opaque_t wasi_config_t
+
+#ccall_unsafe wasi_config_new, IO (Ptr <wasi_config_t>)
+#ccall_unsafe wasi_config_inherit_argv, Ptr <wasi_config_t> -> IO ()
+#ccall_unsafe wasi_config_inherit_stdin, Ptr <wasi_config_t> -> IO ()
+#ccall_unsafe wasi_config_inherit_stderr, Ptr <wasi_config_t> -> IO ()
+#ccall_unsafe wasi_config_inherit_stdout, Ptr <wasi_config_t> -> IO ()

--- a/test/wasi-hello.hs
+++ b/test/wasi-hello.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+-- | Haskell translation of: https://docs.wasmtime.dev/examples-c-hello-world.html
+module Main (main) where
+
+import Control.Exception (Exception, throwIO)
+import qualified Data.ByteString as B
+import Paths_wasmtime_hs (getDataFileName)
+import Wasmtime
+import Data.Int
+
+main :: IO ()
+main = do
+  putStrLn "Initializing..."
+  engine <- newEngine
+
+  store <- newStore engine >>= handleException
+
+  helloWatPath <- getDataFileName "test/wasi_hello.wat"
+  watBytes <- B.readFile helloWatPath
+
+  wasm <- handleException $ wat2wasm watBytes
+
+  putStrLn "Compiling module..."
+  myModule <- handleException $ newModule engine wasm
+
+  putStrLn "Linking wasi..."
+  linker <- newLinker engine
+  linkerDefineWasiWith (wasiInheritArgv <> wasiInheritStderr <> wasiInheritStdin <> wasiInheritStdout) linker store >>= handleException
+
+  putStrLn "Instantiating module..."
+  inst <- linkerInstantiate linker store myModule >>= handleException
+
+  putStrLn "Extracting export..."
+  Just (run :: IO (Either WasmException Int32)) <-
+    getExportedFunction store inst "run"
+
+  putStrLn "Calling export..."
+  _ <- run >>= handleException
+
+  putStrLn "All finished!"
+
+handleException :: Exception e => Either e r -> IO r
+handleException = either throwIO pure

--- a/test/wasi_hello.wat
+++ b/test/wasi_hello.wat
@@ -1,0 +1,25 @@
+(module
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32))
+  )
+  (memory 1)
+  (export "memory" (memory 0)) 
+  (data (i32.const 0) "Hello, World!\n")
+
+  (func $hello_world (result i32)
+    (local $iovs i32)
+
+    (i32.store (i32.const 16) (i32.const 0))
+    (i32.store (i32.const 20) (i32.const 14))
+
+    (local.set $iovs (i32.const 16))
+
+    (call $fd_write
+      (i32.const 1)
+      (local.get $iovs)
+      (i32.const 1)
+      (i32.const 24)
+    )
+  )
+  (export "run" (func $hello_world))
+)

--- a/wasmtime-hs.cabal
+++ b/wasmtime-hs.cabal
@@ -175,3 +175,17 @@ executable err
     build-depends:    bytestring
     build-depends:    primitive
     build-depends:    wasmtime-hs
+
+test-suite wasi-hello
+    import:           warnings
+    type:             exitcode-stdio-1.0
+
+    default-language: Haskell2010
+    hs-source-dirs:   test
+    main-is:          wasi-hello.hs
+    other-modules:    Paths_wasmtime_hs
+
+    build-depends:    base >=4.15
+    build-depends:    bytestring
+    build-depends:    primitive
+    build-depends:    wasmtime-hs


### PR DESCRIPTION
Fixed #49 .

### Improvement WASI

- Add `linkerDefineWasiWith`
  - This function is taken `WasiConfig` and exec `wasmtime_context_set_wasi`
  - `WasiConfig` is `Monoid`, so it can be used like `WasmConfig`
- Write the test of this feature in `test/wasi-hello.hs`




