### PR TITLE
Use a caller in a callback

### DIFF
--- a/lib/Wasmtime.hs
+++ b/lib/Wasmtime.hs
@@ -3058,6 +3058,13 @@ linkerDefineFunc linker modName name f =
     callback = mkCallback f
 
 -- | Defines a new function taken a caller in this linker.
+--
+-- A function taken a caller requires type annotation.
+-- @
+--   someFunc :: s ~ PrimState IO => Caller s -> Int32 -> IO (Either Trap Int32)
+--   someFunc caller x =  do
+--  ...
+-- @
 linkerDefineFuncWithCaller ::
   forall f m s.
   ( Funcable f,
@@ -3133,8 +3140,6 @@ linkerDefineInstance linker store name inst =
               name_ptr
               (fromIntegral name_sz)
               >=> try . checkWasmtimeError
-
--- TODO: Bind wasmtime_context_set_wasi
 
 -- | Defines WASI functions in this linker.
 --

--- a/lib/Wasmtime.hs
+++ b/lib/Wasmtime.hs
@@ -1315,8 +1315,8 @@ class Val a where
   pokeRawVal :: Store s -> Ptr C'wasmtime_val_raw_t -> a -> IO ()
   peekRawVal :: Store s -> Ptr C'wasmtime_val_raw_t -> IO a
 
-  pokeRawValWithCaller :: Caller -> Ptr C'wasmtime_val_raw_t -> a -> IO ()
-  peekRawValWithCaller :: Caller -> Ptr C'wasmtime_val_raw_t -> IO a
+  pokeRawValWithCaller :: Caller s -> Ptr C'wasmtime_val_raw_t -> a -> IO ()
+  peekRawValWithCaller :: Caller s -> Ptr C'wasmtime_val_raw_t -> IO a
 
   default pokeVal :: (Storable a) => Ptr C'wasmtime_val_t -> a -> IO ()
   pokeVal val_ptr x = do
@@ -1347,10 +1347,10 @@ class Val a where
   default peekRawVal :: (Storable a) => Store s -> Ptr C'wasmtime_val_raw_t -> IO a
   peekRawVal _store = peek . castPtr
 
-  default pokeRawValWithCaller :: (Storable a) => Caller -> Ptr C'wasmtime_val_raw_t -> a -> IO ()
+  default pokeRawValWithCaller :: (Storable a) => Caller s -> Ptr C'wasmtime_val_raw_t -> a -> IO ()
   pokeRawValWithCaller  _ = poke . castPtr
 
-  default peekRawValWithCaller :: (Storable a) => Caller -> Ptr C'wasmtime_val_raw_t -> IO a
+  default peekRawValWithCaller :: (Storable a) => Caller s -> Ptr C'wasmtime_val_raw_t -> IO a
   peekRawValWithCaller _ = peek . castPtr
 
 instance Val Int32 where kind _proxy = c'WASMTIME_I32
@@ -1423,8 +1423,8 @@ class Vals (v :: [Type]) where
   peekVals :: Ptr C'wasmtime_val_t -> MaybeT IO (List v)
   pokeRawVals :: Store s -> Ptr C'wasmtime_val_raw_t -> List v -> IO ()
   peekRawVals :: Store s -> Ptr C'wasmtime_val_raw_t -> IO (List v)
-  pokeRawValsWithCaller :: Caller -> Ptr C'wasmtime_val_raw_t -> List v -> IO ()
-  peekRawValsWithCaller :: Caller -> Ptr C'wasmtime_val_raw_t -> IO (List v)
+  pokeRawValsWithCaller :: Caller s -> Ptr C'wasmtime_val_raw_t -> List v -> IO ()
+  peekRawValsWithCaller :: Caller s -> Ptr C'wasmtime_val_raw_t -> IO (List v)
 
 instance Vals '[] where
   pokeValTypes _valtypes_ptr_ptr _proxy = pure ()
@@ -1501,9 +1501,9 @@ instance HasForeignPtr (Func s) C'wasmtime_func_t where
   getForeignPtr = unFunc
 
 -- | Representation of a caller in Wasmtime.
-newtype Caller = Caller {unCaller :: ForeignPtr C'wasmtime_caller_t}
+newtype Caller s = Caller {unCaller :: ForeignPtr C'wasmtime_caller_t}
 
-instance HasForeignPtr (Caller) C'wasmtime_caller_t where
+instance HasForeignPtr (Caller s) C'wasmtime_caller_t where
   getForeignPtr = unCaller
 
 -- | Returns the type of the given function.
@@ -1515,7 +1515,7 @@ getFuncType store func =
         mask_ $
           unsafe'c'wasmtime_func_type ctx_ptr func_ptr >>= newFuncTypeFromPtr
 
-getFuncTypeFromCaller :: (MonadPrim s m) => Caller -> Func s -> m FuncType
+getFuncTypeFromCaller :: (MonadPrim s m) => Caller s -> Func s -> m FuncType
 getFuncTypeFromCaller caller func =
   unsafeIOToPrim $ 
     withObj caller $ \caller_ptr -> do
@@ -1642,7 +1642,7 @@ mkCallbackWithCaller ::
     MonadPrim s m,
     PrimBase m
   ) =>
-  (Caller -> f) ->
+  (Caller s -> f) ->
   FuncCallback
 mkCallbackWithCaller f0 _env caller0 params_ptr nargs result_ptr nresults = do
   caller <- Caller <$> unsafePrimToIO (newForeignPtr_ caller0)
@@ -1833,7 +1833,7 @@ funcToFunctionWithCaller ::
     Action f ~ m (Either WasmException (Result f)),
     MonadPrim s m
   ) =>
-  Caller ->
+  Caller s ->
   -- | WASM function.
   Func s ->
   m (Maybe f)
@@ -1885,7 +1885,7 @@ callFuncWithCaller ::
     Action f ~ m (Either WasmException (Result f)),
     MonadPrim s m
   ) =>
-  Caller ->
+  Caller s ->
   -- | See 'funcToFunction'.
   Func s ->
   f
@@ -1914,7 +1914,7 @@ callFuncWithCaller caller func = curryList callFuncOnParams
     n = max (len $ Proxy @(Params f)) (len $ Proxy @(Types (Result f)))
 
 -- | Get an export by name from a caller
-getExportFromCaller :: (MonadPrim s m) => Caller -> String -> m (Maybe (Extern s))
+getExportFromCaller :: (MonadPrim s m) => Caller s -> String -> m (Maybe (Extern s))
 getExportFromCaller caller name = unsafeIOToPrim $
   withObj caller $ \caller_ptr -> do
     withCStringLen name $ \(name_ptr, sz) ->
@@ -1939,7 +1939,7 @@ getExportedFunctionFromCaller ::
     Action f ~ m (Either WasmException (Result f)),
     MonadPrim s m
   ) =>
-  Caller ->
+  Caller s ->
   -- | Name of the export.
   String ->
   m (Maybe f)
@@ -1953,7 +1953,7 @@ getExportedFunctionFromCaller caller name = runMaybeT $ do
 getExportedMemoryFromCaller ::
   forall s m.
   (MonadPrim s m) =>
-  Caller ->
+  Caller s ->
   -- | Name of the export.
   String ->
   m (Maybe (Memory s))
@@ -1964,7 +1964,7 @@ getExportedMemoryFromCaller caller name = (>>= fromExtern) <$> getExportFromCall
 getExportedTableFromCaller ::
   forall s m.
   (MonadPrim s m) =>
-  Caller ->
+  Caller s ->
   -- | Name of the export.
   String ->
   m (Maybe (Table s))
@@ -1976,7 +1976,7 @@ getExportedTableFromCaller caller name = (>>= fromExtern) <$> getExportFromCalle
 getExportedTypedGlobalFromCaller ::
   forall s m a.
   (MonadPrim s m, Val a) =>
-  Caller ->
+  Caller s ->
   -- | Name of the export.
   String ->
   m (Maybe (TypedGlobal s a))
@@ -2087,7 +2087,7 @@ getGlobalType store global =
         globaltype_ptr <- unsafe'c'wasmtime_global_type ctx_ptr global_ptr
         newGlobalTypeFromPtr globaltype_ptr
 
-getGlobalTypeFromCaller :: (MonadPrim s m) => Caller -> Global s -> m GlobalType
+getGlobalTypeFromCaller :: (MonadPrim s m) => Caller s -> Global s -> m GlobalType
 getGlobalTypeFromCaller caller global =
   unsafeIOToPrim $
     withObj caller $ \caller_ptr ->
@@ -2115,7 +2115,7 @@ toTypedGlobal store global = do
 toTypedGlobalFromCaller ::
   forall s m a.
   (MonadPrim s m, Val a) =>
-  Caller ->
+  Caller s ->
   Global s ->
   m (Maybe (TypedGlobal s a))
 toTypedGlobalFromCaller caller global = do
@@ -3071,7 +3071,7 @@ linkerDefineFuncWithCaller ::
   ModuleName ->
   -- | The field name the item is defined under
   Name ->
-  (Caller -> f) ->
+  (Caller s -> f) ->
   m (Either WasmtimeError ())
 linkerDefineFuncWithCaller linker modName name f =
   unsafeIOToPrim $

--- a/test/caller.hs
+++ b/test/caller.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 -- | Haskell translation of: https://docs.wasmtime.dev/examples-c-hello-world.html
@@ -11,10 +12,13 @@ import Paths_wasmtime_hs (getDataFileName)
 import Data.Int
 import Test.Tasty.HUnit ((@?=))
 import Wasmtime
+import Control.Monad.Primitive
 
 main :: IO ()
 main = do
   engine <- newEngine
+  
+  store <- newStore engine >>= handleException
 
   linker <- newLinker engine 
   linkerDefineFuncWithCaller linker "" "someFunc" someFunc >>= handleException
@@ -26,8 +30,6 @@ main = do
 
   myModule <- handleException $ newModule engine wasm
 
-  store <- newStore engine >>= handleException
-
   inst <- linkerInstantiate linker store myModule >>= handleException
 
   -- run x = someFunc (x + 1)
@@ -37,11 +39,12 @@ main = do
   result <- run 2 >>= handleException
   result @?= 6
 
-someFunc :: Caller -> Int32 -> IO (Either Trap Int32)
-someFunc caller x = Right <$> do
+someFunc :: s ~ PrimState IO => Caller s -> Int32 -> IO (Either Trap Int32)
+someFunc caller x =  do
   putStrLn $ "> someFunc got: " <> show x
   Just (double :: Int32 -> IO (Either WasmException Int32)) <- getExportedFunctionFromCaller caller "double"
-  double x >>= handleException
+  result <- double x >>= handleException
+  pure $ Right result
 
 handleException :: Exception e => Either e r -> IO r
 handleException = either throwIO pure

--- a/test/caller.wat
+++ b/test/caller.wat
@@ -1,0 +1,5 @@
+(module
+  (func $some_func (import "" "some_func") (param i32) (result i32))
+  (func (export "double") (param i32) (result i32) (local.get 0) (i32.const 2) (i32.mul))
+  (func (export "run") (param i32) (result i32) (local.get 0) (i32.const 1) (i32.add) (call $someFunc))
+)

--- a/test/caller.wat
+++ b/test/caller.wat
@@ -1,5 +1,5 @@
 (module
-  (func $some_func (import "" "some_func") (param i32) (result i32))
+  (func $someFunc (import "" "someFunc") (param i32) (result i32))
   (func (export "double") (param i32) (result i32) (local.get 0) (i32.const 2) (i32.mul))
   (func (export "run") (param i32) (result i32) (local.get 0) (i32.const 1) (i32.add) (call $someFunc))
 )


### PR DESCRIPTION
Fixed #50 .

### Using caller

- Add some functions to get exported things in that callback function
  - The callback requires type annotation because of matching phantom type in `Store s` between externs.
 - The test is `test/caller.hs`