### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,6 +8,6 @@ on:
 jobs:
   checks-linux:
     if: false # disable for now since it's failing
-    uses: nixbuild/nixbuild-action/.github/workflows/ci-workflow.yml@v17
+    uses: nixbuild/nixbuild-action/.github/workflows/ci-workflow.yml@2c22043033fd4118ff8f465d59e1edb7619fca74 # v17
     secrets:
       nixbuild_ssh_key: ${{ secrets.SSH_KEY_FOR_NIXBUILD }}


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `nixbuild/nixbuild-action/.github/workflows/ci-workflow.yml@v17` -> `nixbuild/nixbuild-action/.github/workflows/ci-workflow.yml@2c22043033fd4118ff8f465d59e1edb7619fca74 # v17`
  - Version: v17 | Latest: v24 | Release age: 156d
  - Commit: https://github.com/nixbuild/nixbuild-action/commit/2c22043033fd4118ff8f465d59e1edb7619fca74


### Files modified

- `.github/workflows/checks.yml`